### PR TITLE
Added ability to configure Box.com direct download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/lti-courses",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Courses LTI Tool",
   "main": "src/index.js",
   "publishConfig": {
@@ -17,20 +17,17 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.2.0",
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^10.0.0",
     "eslint": "^6.2.1"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
-    "react-final-form": "^6.3.0",
-    "react-final-form-arrays": "^3.1.0",
-    "redux-form": "^7.0.0"
+    "redux-form": "^8.3.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "react": "*",
-    "react-intl": "^4.5.1"
+    "react-intl": "^5.7.0"
   },
   "stripes": {
     "actsAs": [

--- a/src/PlatformSettings/PlatformDetail.js
+++ b/src/PlatformSettings/PlatformDetail.js
@@ -48,7 +48,7 @@ const PlatformDetail = ({
       />
       <KeyValue
         label={<FormattedMessage id="ui-lti-courses.platform.boxDirectDownload" />}
-        value={platform.boxDirectDownload ? <FormattedMessage id="ui-lti-courses.yes" /> : <FormattedMessage id="ui-lti-courses.no" /> }
+        value={platform.boxDirectDownload ? <FormattedMessage id="ui-lti-courses.yes" /> : <FormattedMessage id="ui-lti-courses.no" />}
       />
     </>
   );

--- a/src/PlatformSettings/PlatformDetail.js
+++ b/src/PlatformSettings/PlatformDetail.js
@@ -46,6 +46,10 @@ const PlatformDetail = ({
         label={<FormattedMessage id="ui-lti-courses.platform.noReservesMessage" />}
         value={platform.noReservesMessage ?? <NoValue />}
       />
+      <KeyValue
+        label={<FormattedMessage id="ui-lti-courses.platform.boxDirectDownload" />}
+        value={platform.boxDirectDownload ? <FormattedMessage id="ui-lti-courses.yes" /> : <FormattedMessage id="ui-lti-courses.no" /> }
+      />
     </>
   );
 };

--- a/src/PlatformSettings/PlatformForm.js
+++ b/src/PlatformSettings/PlatformForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
-import { Layout, TextField } from '@folio/stripes/components';
+import { Checkbox, Layout, TextField } from '@folio/stripes/components';
 
 export default () => (
   <Layout className="padding-bottom-gutter">
@@ -70,6 +70,15 @@ export default () => (
     />
     <Layout className="padding-bottom-gutter">
       <FormattedMessage id="ui-lti-courses.platform.noReservesMessage.description" />
+    </Layout>
+    <Field
+      component={Checkbox}
+      label={<FormattedMessage id="ui-lti-courses.platform.boxDirectDownload" />}
+      name="value.boxDirectDownload"
+      type="checkbox"
+    />
+    <Layout className="padding-bottom-gutter">
+      <FormattedMessage id="ui-lti-courses.platform.boxDirectDownload.description" />
     </Layout>
   </Layout>
 );

--- a/translations/ui-lti-courses/en.json
+++ b/translations/ui-lti-courses/en.json
@@ -19,6 +19,11 @@
   "platform.oidcAuthUrl.description": "Ensure that this URL is publicly accessible. Unless they are properly configured, some LMSs provide a URL that doesn't account for things like reverse proxies.",
   "platform.searchUrl": "Public search URL",
   "platform.searchUrl.description": "<div>The public search URL will be used for creating links when no electronic access is defined for the reserved item. Some variables can be inserted into the URL, e.g., https://find.mylibrary.edu?query=[BARCODE]. The supported variables are:</div><ul><li>[BARCODE] - The item's barcode</li><li>[INSTANCE_HRID] - The instance's HRID</li></ul>",
+  "platform.boxDirectDownload": "Transform reserve URLs including \"box.com\" to direct-download using the Box API",
+  "platform.boxDirectDownload.description": "When an item has Electronic Access and the URL contains \"box.com\", the LTI edge module can rewrite the link so that it transparently offers the item for download rather than linking the user to box.com. Note that the edge module must have been launched with a valid Access Token for the Box API, see the documentation for the edge-lti-courses module for more details.",
+
+  "yes": "Yes",
+  "no": "No",
 
   "errors.issuersMustBeUnique": "A platform with this issuer already exists. Issuers must be unique."
 }


### PR DESCRIPTION
This adds the ability to configure a platform's usage of the box.com direct download functionality, [which is introduced in the edge module here](https://github.com/folio-org/edge-lti-courses/pull/8).